### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for generating images using Black Forest Lab's FLUX model. Uses the latest MCP SDK (v1.7.0).
 
+<a href="https://glama.ai/mcp/servers/@frankdeno/flux-image-generator-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@frankdeno/flux-image-generator-mcp/badge" alt="FLUX Image Generator Server MCP server" />
+</a>
+
 ## Features
 
 - Generate images based on text prompts


### PR DESCRIPTION
This PR adds a badge for the [FLUX Image Generator MCP Server](https://glama.ai/mcp/servers/@frankdeno/flux-image-generator-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@frankdeno/flux-image-generator-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@frankdeno/flux-image-generator-mcp/badge" alt="FLUX Image Generator Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.